### PR TITLE
Update to Go 1.7.4

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,12 +1,13 @@
 machine:
   environment:
-    GODIST: "go1.7.3.linux-amd64.tar.gz"
+    GODIST: "go1.7.4.linux-amd64.tar.gz"
+
   post:
     - mkdir -p download
     - test -e download/$GODIST || curl -o download/$GODIST https://storage.googleapis.com/golang/$GODIST
     - sudo rm -rf /usr/local/go
     - sudo tar -C /usr/local -xzf download/$GODIST
-    
+
 dependencies:
   override:
     - rm -rf "$HOME/src/github.com/Shyp/go-git"
@@ -16,4 +17,5 @@ dependencies:
 
 test:
   override:
+    - go version
     - make test


### PR DESCRIPTION
1.7.4 fixes an issue where Go incorrectly trusted Apple root certificates that
are marked by the operating system as untrusted.