### PR TITLE
Allow parsing HTTPS remotes with no .git on the end

### DIFF
--- a/git.go
+++ b/git.go
@@ -24,7 +24,7 @@ const (
 var sshExp = regexp.MustCompile("^(?P<sshUser>[^@]+)@(?P<domain>[^:]+):(?P<pathRepo>.*)\\.git/?$")
 
 // https://github.com/Shyp/shyp_api.git
-var httpsExp = regexp.MustCompile("^https://(?P<domain>[^/:]+)(:(?P<port>[[0-9]+))?/(?P<pathRepo>.*)\\.git/?$")
+var httpsExp = regexp.MustCompile("^https://(?P<domain>[^/:]+)(:(?P<port>[[0-9]+))?/(?P<pathRepo>.+?)(\\.git/?)?$")
 
 // A remote URL. Easiest to describe with an example:
 //

--- a/git_test.go
+++ b/git_test.go
@@ -1,21 +1,25 @@
 package git
 
 import (
-	"fmt"
+	"reflect"
 	"testing"
 )
 
 func TestCurrentBranch(t *testing.T) {
 	result, err := CurrentBranch()
-	fmt.Println(err)
-	fmt.Println(result)
-	fmt.Println(len(result))
+	// TODO find a way to test this that does not rely on the current state of
+	// the git repository.
+	_ = err
+	_ = result
 }
 
 func TestRoot(t *testing.T) {
 	result, err := Root()
-	fmt.Println(err)
-	fmt.Println(result)
+	// TODO figure out a way to test this as well - it depends on your current
+	// working directory, and you can run "go test" from anywhere on the
+	// filesystem.
+	_ = err
+	_ = result
 }
 
 var remoteTests = []struct {
@@ -82,6 +86,26 @@ var remoteTests = []struct {
 			URL:      "https://github.com:11443/Shyp/shyp_api.git",
 			SSHUser:  "",
 		},
+	}, {
+		"https://github.com/Shyp/shyp_api", RemoteURL{
+			Path:     "Shyp",
+			Host:     "github.com",
+			Port:     443,
+			RepoName: "shyp_api",
+			Format:   HTTPSFormat,
+			URL:      "https://github.com/Shyp/shyp_api",
+			SSHUser:  "",
+		},
+	}, {
+		"https://github.com/Shyp/repo.name.with.periods.git", RemoteURL{
+			Path:     "Shyp",
+			Host:     "github.com",
+			Port:     443,
+			RepoName: "repo.name.with.periods",
+			Format:   HTTPSFormat,
+			URL:      "https://github.com/Shyp/repo.name.with.periods.git",
+			SSHUser:  "",
+		},
 	},
 }
 
@@ -94,7 +118,7 @@ func TestParseRemoteURL(t *testing.T) {
 		if remote == nil {
 			t.Fatalf("expected ParseRemoteURL(%s) to be %v, was nil", tt.remote, tt.expected)
 		}
-		if *remote != tt.expected {
+		if !reflect.DeepEqual(*remote, tt.expected) {
 			t.Errorf("expected ParseRemoteURL(%s) to be %#v, was %#v", tt.remote, tt.expected, remote)
 		}
 	}


### PR DESCRIPTION
"go get github.com/foo/bar" sets the git remote to
"https://github.com/foo/bar", not "https://github.com/foo/bar.git". The former
is supported by Github and "git fetch" and we should support it. Updates the
regex to make this work.